### PR TITLE
Adjustments to your original PR

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -2042,6 +2042,14 @@ describe "TextEditor", ->
             expect(editor.lineTextForBufferRow(4)).toBe "      current = items.shift();"
             expect(editor.lineTextForBufferRow(5)).toBe "    while(items.length > 0) {"
 
+        describe "when some of the selections span the same lines", ->
+          it "moves lines that contain multiple selections correctly", ->
+            editor.setSelectedBufferRanges([[[3, 2], [3, 9]], [[3, 12], [3, 13]]])
+            editor.moveLineUp()
+
+            expect(editor.getSelectedBufferRanges()).toEqual [[[2, 2], [2, 9]], [[2, 12], [2, 13]]]
+            expect(editor.lineTextForBufferRow(2)).toBe "    var pivot = items.shift(), current, left = [], right = [];"
+
         describe "when one of the selections spans line 0", ->
           it "doesn't move any lines, since line 0 can't move", ->
             editor.setSelectedBufferRanges([[[0, 2], [1, 9]], [[2, 2], [2, 9]], [[4, 2], [4, 9]]])

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -837,8 +837,8 @@ class TextEditor extends Model
           rows.pop() unless @isFoldedAtBufferRow(selection.end.row)
 
         # Move line around the fold that is directly above the selection
-        precedingScreenRow = @screenPositionForBufferPosition([selection.start.row]).translate([-1])
-        precedingBufferRow = @bufferPositionForScreenPosition(precedingScreenRow).row
+        precedingScreenRow = @screenRowForBufferRow(selection.start.row) - 1
+        precedingBufferRow = @bufferRowForScreenRow(precedingScreenRow)
         if fold = @largestFoldContainingBufferRow(precedingBufferRow)
           insertDelta = fold.getBufferRange().getRowCount()
         else

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -823,14 +823,14 @@ class TextEditor extends Model
   moveLineUp: ->
     newSelectionBufferRanges = []
     selections = @getSelectedBufferRanges()
-    selections.sort (a, b) ->
-      a.compare(b)
-    for selection in selections
-      return if selection.start.row is 0
-      lastRow = @buffer.getLastRow()
-      return if selection.isEmpty() and selection.start.row is lastRow and @buffer.getLastLine() is ''
+    selections.sort (a, b) -> a.compare(b)
 
-      @transact =>
+    @transact =>
+      for selection in selections
+        continue if selection.start.row is 0
+        lastRow = @buffer.getLastRow()
+        continue if selection.isEmpty() and selection.start.row is lastRow and @buffer.getLastLine() is ''
+
         foldedRows = []
         rows = [selection.start.row..selection.end.row]
         if selection.start.row isnt selection.end.row and selection.end.column is 0
@@ -875,7 +875,7 @@ class TextEditor extends Model
 
         newSelectionBufferRanges.push(selection.translate([-insertDelta]))
 
-    @setSelectedBufferRanges(newSelectionBufferRanges, preserveFolds: true, autoscroll: true)
+      @setSelectedBufferRanges(newSelectionBufferRanges, preserveFolds: true, autoscroll: true)
 
   # Move lines intersecting the most recent selection or muiltiple selections down by one row in screen
   # coordinates.

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -856,8 +856,7 @@ class TextEditor extends Model
           insertPosition = Point.fromObject([startRow - insertDelta])
           endPosition = Point.min([endRow + 1], @buffer.getEndPosition())
           lines = @buffer.getTextInRange([[startRow], endPosition])
-          if endPosition.row is lastRow and endPosition.column > 0 and not @buffer.lineEndingForRow(endPosition.row)
-            lines = "#{lines}\n"
+          lines += @buffer.lineEndingForRow(endPosition.row - 1) unless lines[lines.length - 1] is '\n'
 
           @buffer.deleteRows(startRow, endRow)
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -821,7 +821,6 @@ class TextEditor extends Model
   # Move lines intersection the most recent selection or multiple selections up by one row in screen
   # coordinates.
   moveLineUp: ->
-    newSelectionBufferRanges = []
     selections = @getSelectionsOrderedByBufferPosition()
 
     if selections[0].getBufferRange().start.row is 0
@@ -872,9 +871,7 @@ class TextEditor extends Model
         for foldedRow in foldedRows when 0 <= foldedRow <= @getLastBufferRow()
           @foldBufferRow(foldedRow)
 
-        newSelectionBufferRanges.push(selectionRange.translate([-insertDelta]))
-
-      @setSelectedBufferRanges(newSelectionBufferRanges, preserveFolds: true, autoscroll: true)
+        selection.setBufferRange(selectionRange.translate([-insertDelta, 0]))
 
   # Move lines intersecting the most recent selection or muiltiple selections down by one row in screen
   # coordinates.

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -830,34 +830,48 @@ class TextEditor extends Model
       return
 
     @transact =>
-      for selection in selections
-        selectionRange = selection.getBufferRange()
+      newSelectionRanges = []
+
+      while selections.length > 0
+        # Find selections spanning a contiguous set of lines
+        selection = selections.shift()
+        lastSelectionRange = selection.getBufferRange()
+        selectionsToMove = [selection]
+        rangesOfSelectionsToMove = [lastSelectionRange]
+
+        while lastSelectionRange.end.row is selections[0]?.getBufferRange().start.row
+          selection = selections.shift()
+          lastSelectionRange = selection.getBufferRange()
+          selectionsToMove.push(selection)
+          rangesOfSelectionsToMove.push(lastSelectionRange)
+
+        # Compute the range spanned by all these selections...
+        linesRangeStart = [selectionsToMove[0].getBufferRange().start.row, 0]
+        if lastSelectionRange.end.row > lastSelectionRange.start.row and lastSelectionRange.end.column is 0
+          # Don't move the last line of a multi-line selection if the selection ends at column 0
+          linesRange = new Range(linesRangeStart, lastSelectionRange.end)
+        else
+          linesRange = new Range(linesRangeStart, [lastSelectionRange.end.row + 1, 0])
 
         # If selected line range is preceded by a fold, one line above on screen
         # could be multiple lines in the buffer.
-        precedingScreenRow = @screenRowForBufferRow(selectionRange.start.row) - 1
+        precedingScreenRow = @screenRowForBufferRow(linesRange.start.row) - 1
         precedingBufferRow = @bufferRowForScreenRow(precedingScreenRow)
-        insertDelta = selectionRange.start.row - precedingBufferRow
+        insertDelta = linesRange.start.row - precedingBufferRow
 
         # Any folds in the text that is moved will need to be re-created.
         rangesToRefold =
-          @outermostFoldsInBufferRowRange(selectionRange.start.row, selectionRange.end.row).map (fold) ->
+          @outermostFoldsInBufferRowRange(linesRange.start.row, linesRange.end.row).map (fold) ->
             fold.getBufferRange().translate([-insertDelta, 0])
 
         # Make sure the inserted text doesn't go into an existing fold
         if fold = @displayBuffer.largestFoldStartingAtBufferRow(precedingBufferRow)
-          rangesToRefold.push(fold.getBufferRange().translate([selectionRange.getRowCount(), 0]))
+          rangesToRefold.push(fold.getBufferRange().translate([linesRange.getRowCount(), 0]))
           fold.destroy()
-
-        # Don't move the last line of a multi-line selection if the selection ends at column 0
-        if selectionRange.end.row > selectionRange.start.row and selectionRange.end.column is 0
-          linesRange = [[selectionRange.start.row, 0], selectionRange.end]
-        else
-          linesRange = [[selectionRange.start.row, 0], [selectionRange.end.row + 1, 0]]
 
         # Delete lines spanned by selection and insert them on the preceding buffer row
         lines = @buffer.getTextInRange(linesRange)
-        lines += @buffer.lineEndingForRow(selectionRange.end.row - 1) unless lines[lines.length - 1] is '\n'
+        lines += @buffer.lineEndingForRow(linesRange.end.row - 1) unless lines[lines.length - 1] is '\n'
         @buffer.delete(linesRange)
         @buffer.insert([precedingBufferRow, 0], lines)
 
@@ -865,7 +879,10 @@ class TextEditor extends Model
         for rangeToRefold in rangesToRefold
           @displayBuffer.createFold(rangeToRefold.start.row, rangeToRefold.end.row)
 
-        selection.setBufferRange(selectionRange.translate([-insertDelta, 0]))
+        for selection, i in selectionsToMove
+          newSelectionRanges.push(rangesOfSelectionsToMove[i].translate([-insertDelta, 0]))
+
+      @setSelectedBufferRanges(newSelectionRanges)
 
   # Move lines intersecting the most recent selection or muiltiple selections down by one row in screen
   # coordinates.

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -839,10 +839,7 @@ class TextEditor extends Model
         # Move line around the fold that is directly above the selection
         precedingScreenRow = @screenRowForBufferRow(selection.start.row) - 1
         precedingBufferRow = @bufferRowForScreenRow(precedingScreenRow)
-        if fold = @largestFoldContainingBufferRow(precedingBufferRow)
-          insertDelta = fold.getBufferRange().getRowCount()
-        else
-          insertDelta = 1
+        insertDelta = selection.start.row - precedingBufferRow
 
         for row in rows
           if fold = @displayBuffer.largestFoldStartingAtBufferRow(row)

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -825,12 +825,14 @@ class TextEditor extends Model
     selections = @getSelectedBufferRanges()
     selections.sort (a, b) -> a.compare(b)
 
+    if selections[0].start.row is 0
+      return
+
+    if selections[selections.length - 1].start.row is @getLastBufferRow() and @buffer.getLastLine() is ''
+      return
+
     @transact =>
       for selection in selections
-        continue if selection.start.row is 0
-        lastRow = @buffer.getLastRow()
-        continue if selection.isEmpty() and selection.start.row is lastRow and @buffer.getLastLine() is ''
-
         foldedRows = []
         rows = [selection.start.row..selection.end.row]
         if selection.start.row isnt selection.end.row and selection.end.column is 0


### PR DESCRIPTION
Hi @lpommers... thanks for the awesome PR for moving lines around. There was an issue when multiple cursors were on the same line, which I fixed. I also made some adjustments to use fewer resources, like grouping line movements in a minimal number of transactions. I'm wondering if we can discuss my changes to `moveLineUp` and then you could apply a similar treatment to `moveLineDown` so we can merge your PR... Thanks!
